### PR TITLE
Logitech f710 config and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 [![Build Status](https://travis-ci.org/autorope/donkeypart_bluetooth_game_controller.svg?branch=master)](https://travis-ci.org/autorope/donkeypart_bluetooth_game_controller)
 
-# Bluetooth Game Controller
-This is a library to connect a [Wii-U](https://www.amazon.com/gp/product/B01GJBUNTG/ref=as_li_ss_tl?ie=UTF8&psc=1&linkCode=ll1&tag=donkeycar-20&linkId=a7fc2ff3e6489b9e6dd267a7f8b2ff19&language=en_US)
- (and possibly others) bluetooth game controller to your donkeycar.
+# Bluetooth/Wireless Game Controllers
+This is a library to connect a [Wii-U](https://www.amazon.com/gp/product/B01GJBUNTG/ref=as_li_ss_tl?ie=UTF8&psc=1&linkCode=ll1&tag=donkeycar-20&linkId=a7fc2ff3e6489b9e6dd267a7f8b2ff19&language=en_US), 
+[Logitech F710 gamepad](https://www.amazon.com/dp/B0041RR0TW/ref=cm_sw_em_r_mt_dp_U_0b.MCbMYK2VQ5)
+ (and possibly other) Bluetooth/Wireless game controllers to your donkeycar.
  
  >> See the bottom of the page for tested controllers and brands. Beware of knockoffs!
 
@@ -15,8 +16,8 @@ git clone https://github.com/autorope/donkeypart_bluetooth_game_controller.git
 pip install -e ./donkeypart_bluetooth_game_controller
 ```
 
-
-### Connect your bluetooth controller to the raspberry pi.
+## Connecting the wireless conyroller to pi
+### Connect your bluetooth controller to the raspberry pi. (Wii-u scenario)
 1. Start the bluetooth bash tool on your raspberry pi.
 ```bash
 sudo bluetoothctl
@@ -59,7 +60,18 @@ from donkeypart_bluetooth_game_controller import BluetoothGameController
 ctl = BluetoothGameController()
 
 ```
-## Add a new type of bluetooth controller.
+### Connect your wireless controller to your pi (Logitech F710 Scenario)
+1. Plug-in the USB dongle to the raspberry pi. No pairing steps needed. (If you care to see ... dmesg will list messages related to device enumeration )
+```bash
+pi@donkeypi:~ $ dmesg
+[   87.432464] usb 1-1.2: new full-speed USB device number 5 using dwc_otg
+[   87.570364] usb 1-1.2: New USB device found, idVendor=046d, idProduct=c21f
+...
+[   87.611140] input: Logitech Gamepad F710 as /devices/platform/soc/3f980000.usb/usb1/1-1/1-1.2/1-1.2:1.0/input/input0
+[   87.611350] usbcore: registered new interface driver xpad
+
+```
+## Add a new type of bluetooth/wireless controller.
 If you don't have a different type of controller these same instructions should work but the button mappings will be different.
 
 1. Use the this same script to show the live output of your controller...
@@ -81,6 +93,7 @@ ctl = BluetoothGameController(config=/path/to/your/config/file)
 
 ## Works
 * Wii U Pro Controller by Nintendo
+* Logitech Gamepad F710 (leave the mode select switch in the default position, i.e select (Xpad mode) and not D)
 
 
 ## Kind of Works (Not Recommended)
@@ -92,5 +105,11 @@ ctl = BluetoothGameController(config=/path/to/your/config/file)
 Run the profile script to see the number of events per second you recieve from the controller. Then make a pull request 
 to update this document to help others.
 ```
-python ./donkeypart_bluetooth_game_controller/donkeyblue/part.py log
+python ./donkeypart_bluetooth_game_controller/donkeyblue/part.py profile
 ```
+
+## Controller benchmarks
+These were the Maximum and Average Events per sec reported by the aforementioned profile switch on the same Raspberry Pi (decimal places have been removed for readbility):
+* Logitech F710 - Events per second -  MAX: 226, AVERAGE: 221
+* Wii-U Pro Controller by Nintendo  -   MAX: 63, AVERAGE: 61
+* Wii U Pro Controller by SIBIONO   -    MAX: 53, AVERAGE: 52

--- a/donkeypart_bluetooth_game_controller/logitech_f710_config.yml
+++ b/donkeypart_bluetooth_game_controller/logitech_f710_config.yml
@@ -1,0 +1,32 @@
+
+device_search_term: 'Logitech Gamepad F710'
+
+
+#Map the button codes to the button names
+button_map:
+  304: 'A'
+  305: 'B'
+  307: 'X'
+  308: 'Y'
+  312: 'LEFT_BOTTOM_TRIGGER'
+  310: 'LEFT_TOP_TRIGGER'
+  313: 'RIGHT_BOTTOM_TRIGGER'
+  311: 'RIGHT_TOP_TRIGGER'
+  317: 'LEFT_STICK_PRESS'
+  318: 'RIGHT_STICK_PRESS'
+  314: 'SELECT'
+  315: 'START'
+  0: 'LEFT_STICK_X'
+  1: 'LEFT_STICK_Y'
+  3: 'RIGHT_STICK_X'
+  4: 'RIGHT_STICK_Y'
+  16: 'PAD_RIGHT'
+  16: 'PAD_LEFT'
+  17: 'PAD_UP'
+  17: 'PAD_DOWN'
+
+
+joystick_max_value: 32768
+
+
+

--- a/donkeypart_bluetooth_game_controller/part.py
+++ b/donkeypart_bluetooth_game_controller/part.py
@@ -20,7 +20,7 @@ class BluetoothDevice:
         all_devices = [evdev.InputDevice(path) for path in evdev.list_devices()]
         likely_devices = []
         for device in all_devices:
-            if search_term in device.name.lower():
+            if search_term.lower() in device.name.lower():
                 likely_devices.append(device)
 
         if len(likely_devices) == 1:

--- a/donkeypart_bluetooth_game_controller/part.py
+++ b/donkeypart_bluetooth_game_controller/part.py
@@ -6,6 +6,7 @@ import argparse
 import evdev
 from evdev import ecodes
 import yaml
+import pprint
 
 class BluetoothDevice:
     device = None
@@ -82,6 +83,9 @@ class BluetoothGameController(BluetoothDevice):
             print(self.device)
         else:
             self.device = event_input_device
+
+        if self.verbose == True:
+            pprint.pprint(self.device.capabilities(verbose=True))
 
         self.func_map = {
             'LEFT_STICK_X': self.update_angle,

--- a/donkeypart_bluetooth_game_controller/part.py
+++ b/donkeypart_bluetooth_game_controller/part.py
@@ -47,7 +47,6 @@ class BluetoothGameController(BluetoothDevice):
     """
     Generator of cordinates of a bouncing moving square for simulations.
     """
-
     def __init__(self, event_input_device=None, config_path=None, device_search_term=None, verbose=False):
 
 
@@ -89,12 +88,12 @@ class BluetoothGameController(BluetoothDevice):
             'LEFT_STICK_Y': self.update_throttle,
             'B': self.toggle_recording,
             'A': self.toggle_drive_mode,
-            'PAD_UP': self.increment_throttle_scale,
-            'PAD_DOWN': self.decrement_throttle_scale,
+            'RIGHT_TOP_TRIGGER': self.increment_throttle_scale,
+            'LEFT_TOP_TRIGGER': self.decrement_throttle_scale,
         }
 
     def _get_default_config_path(self):
-        return os.path.join(os.path.dirname(__file__), 'wiiu_config.yml')
+        return os.path.join(os.path.dirname(__file__), 'logitech_f710_config.yml')
 
     def _load_config(self, config_path):
         with open(config_path, 'r') as f:

--- a/donkeypart_bluetooth_game_controller/wiiu_config.yml
+++ b/donkeypart_bluetooth_game_controller/wiiu_config.yml
@@ -26,7 +26,7 @@ button_map:
   548: 'PAD_DOWN'
 
 
-joystic_max_value: 1280
+joystick_max_value: 1280
 
 
 


### PR DESCRIPTION
This series does the following:
1. Adds Logitech F710 Joystick (which uses a proprietary wireless dongle) support to this part
2. Bench-marked it alongside the Wii-U and added the results in README
3. Made some minor enhancements and fixes